### PR TITLE
Strings and Boxed types should be compared using "equals()"

### DIFF
--- a/src/main/java/org/apache/sling/scripting/esx/Module.java
+++ b/src/main/java/org/apache/sling/scripting/esx/Module.java
@@ -505,7 +505,7 @@ public class Module extends SimpleBindings implements Require {
 
         for (int i = (parts.length - 1); i > 0;) {
             log.debug(parts[i]);
-            if (parts[i].equals("node_modules") || parts[i].equals("esx_modules")) {
+            if ("node_modules".equals(parts[i]) || "esx_modules".equals(parts[i])) {
                 continue;
             }
             String part = StringUtils.join(parts, "/", 0, i);

--- a/src/main/java/org/apache/sling/scripting/esx/Module.java
+++ b/src/main/java/org/apache/sling/scripting/esx/Module.java
@@ -505,7 +505,7 @@ public class Module extends SimpleBindings implements Require {
 
         for (int i = (parts.length - 1); i > 0;) {
             log.debug(parts[i]);
-            if (parts[i] == "node_modules" || parts[i] == "esx_modules") {
+            if (parts[i].equals("node_modules") || parts[i].equals("esx_modules")) {
                 continue;
             }
             String part = StringUtils.join(parts, "/", 0, i);


### PR DESCRIPTION
This fixes 2 Sonarqube violations of rule S4973:
https://rules.sonarsource.com/java/RSPEC-4973

Sonarcloud violation URL:
https://sonarcloud.io/organizations/apache/issues?languages=java&open=AWoocNf3MflNeiYSIfWd&resolved=false&rules=squid%3AS4973&types=BUG

Jira Ticket:
https://issues.apache.org/jira/browse/SLING-8825